### PR TITLE
fix faq question to not be opened by default

### DIFF
--- a/_includes/sections/faq.html
+++ b/_includes/sections/faq.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="faq">
-    <details open>
+    <details>
       <summary>Can I bring my keyboards?</summary>
       <p>Yes, please! This is what Mechanicon is all about. We will have enough tables so that everyone can bring their keyboards for display!</p>
     </details>


### PR DESCRIPTION
Without this, the first FAQ question is awkwardly opened when the page is first loaded. This fixes it so all answers are hidden by default.

<img width="1253" height="679" alt="grafik" src="https://github.com/user-attachments/assets/c0e79890-4d2a-4300-9f22-b3e51ae93c3c" />
